### PR TITLE
Change the mapper configuration to treat `byte[0]` as `null` and `null` as `null`

### DIFF
--- a/AutoMapper/Mapper.cs
+++ b/AutoMapper/Mapper.cs
@@ -59,6 +59,7 @@ namespace AutoMapper.DXSdata
                     OnConfiguring(typeof(Mapper).Namespace, new MapperConfiguringEventArgs() { Configuration = cfg });
                     //OnConfiguring(null, EventArgs.Empty);
 
+                cfg.ValueTransformers.Add<byte[]>(val => val.Length == 0 ? null : val);
             });
             return config.CreateMapper();
         }

--- a/MapperTest/MyClass1.cs
+++ b/MapperTest/MyClass1.cs
@@ -12,5 +12,7 @@ namespace MapperTest
         public string Var4 { get; set; }
         public string Var5 { get; set; }
 
+        public byte[] BytesEmpty { get; set; } = new byte[0];
+        public byte[] BytesNull { get; set; } = null;
     }
 }

--- a/MapperTest/MyClass2.cs
+++ b/MapperTest/MyClass2.cs
@@ -10,6 +10,7 @@ namespace MapperTest
         public string Var2 { get; set; }
         public string Var3 { get; set; }
 
-
+        public byte[] BytesEmpty { get; set; }
+        public byte[] BytesNull { get; set; }
     }
 }


### PR DESCRIPTION
By default AutoMapper treats 

- `(byte[])null` as `byte[0]`
- `byte[0]` as`byte[0]`

Now, everything would be treated as `null`